### PR TITLE
Improve html export

### DIFF
--- a/example/initialState/raw.js
+++ b/example/initialState/raw.js
@@ -114,7 +114,7 @@ export default {
       "inlineStyleRanges": [],
       "entityRanges": [],
       "data": {
-        "src": "https://www.youtube.com/watch?v=HBHJ0XGZfLs",
+        "src": "https://www.youtube.com/embed/HBHJ0XGZfLs",
         "type": "video",
         "caption": "Fanta by easyFun",
       }
@@ -127,7 +127,7 @@ export default {
       "inlineStyleRanges": [],
       "entityRanges": [],
       "data": {
-        "src": "https://vimeo.com/713300",
+        "src": "https://player.vimeo.com/video/713300",
         "type": "video"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "webpack-dev-server": "2.1.0-beta.12"
   },
   "dependencies": {
+    "common-tags": "^1.4.0",
     "draft-convert": "^1.3.1",
     "draft-js": "^0.9.1",
     "draft-js-export-html": "^0.5.2",

--- a/src/plugins/video/VideoBlock.js
+++ b/src/plugins/video/VideoBlock.js
@@ -21,44 +21,11 @@ export default class extends Component {
     this.props.container.updateData({caption: event.target.value})
   }
 
-  getVideoIdYoutube(str) {
-    // link : https://youtube.com/watch?v=HBHJ0XGZfLs
-    // share : https://youtu.be/HBHJ0XGZfLs
-    // embed : https://youtube.com/embed/HBHJ0XGZfLs
-    var re = /\/\/(?:www\.)?youtu(?:\.be|be\.com)\/(?:watch\?v=|embed\/)?([a-z0-9_\-]+)/i
-    var matches = re.exec(str)
-    return matches && matches[1]
-  }
-
-  getVideoIdVimeo(str) {
-    // embed & link: https://vimeo.com/713300
-    var re = /\/\/(?:www\.)?vimeo.com\/([0-9a-z\-_]+)/i
-    var matches = re.exec(str)
-    return matches && matches[1]
-  }
-
-  getVideoUrl(src) {
-    /* youtube */
-    let id = this.getVideoIdYoutube(src)
-    if (id !== null) {
-      return `https://youtube.com/embed/${id}`
-    }
-
-    /* vimeo */
-    id = this.getVideoIdVimeo(src)
-    if (id !== null) {
-      return `https://player.vimeo.com/video/${id}`
-    }
-  }
-
   render () {
-    let videoSrc = this.getVideoUrl(this.props.data.src)
-    if(videoSrc === undefined) { return null }
-
     return (
       <Block {...this.props} actions={this.actions}>
         <VideoBlockWrapper className='ld-video-block-wrapper'>
-          <VideoBlock src={videoSrc}
+          <VideoBlock src={this.props.data.src}
                   className='ld-video-block'
                   frameBorder='0'
                   allowFullScreen />

--- a/src/plugins/video/VideoButton.js
+++ b/src/plugins/video/VideoButton.js
@@ -3,12 +3,47 @@ import insertDataBlock from '../../utils/insertDataBlock'
 const styled = require('styled-components').default
 
 export default class extends Component {
+  getVideoIdYoutube(str) {
+    // link : https://youtube.com/watch?v=HBHJ0XGZfLs
+    // share : https://youtu.be/HBHJ0XGZfLs
+    // embed : https://youtube.com/embed/HBHJ0XGZfLs
+    var re = /\/\/(?:www\.)?youtu(?:\.be|be\.com)\/(?:watch\?v=|embed\/)?([a-z0-9_\-]+)/i
+    var matches = re.exec(str)
+    return matches && matches[1]
+  }
+
+  getVideoIdVimeo(str) {
+    // embed & link: https://vimeo.com/713300
+    var re = /\/\/(?:www\.)?vimeo.com\/([0-9a-z\-_]+)/i
+    var matches = re.exec(str)
+    return matches && matches[1]
+  }
+
+
+  getVideoUrl(src) {
+    /* youtube */
+    let id = this.getVideoIdYoutube(src)
+    if (id !== null) {
+      return `https://youtube.com/embed/${id}`
+    }
+
+    /* vimeo */
+    id = this.getVideoIdVimeo(src)
+    if (id !== null) {
+      return `https://player.vimeo.com/video/${id}`
+    }
+    return '';
+  }
+
   onClick (e) {
     e.preventDefault()
     const src = window.prompt('Enter the video URL')
     if (!src) { return }
 
-    const data = {src: src, type: 'video'}
+    let videoSrc = this.getVideoUrl(src)
+    if(videoSrc === undefined) { return }
+
+    const data = {src: videoSrc, type: 'video'}
     this.props.onChange(insertDataBlock(this.props.editorState, data))
   }
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -2,6 +2,7 @@ import {convertFromHTML} from 'draft-convert'
 import {stateToHTML} from 'draft-js-export-html'
 import {Entity, convertToRaw, convertFromRaw, EditorState} from 'draft-js'
 import defaultDecorator from '../decorators/defaultDecorator'
+import {html} from 'common-tags'
 
 export function editorStateFromHtml (html, decorator = defaultDecorator) {
   if (html === null) {
@@ -54,9 +55,31 @@ export function editorStateToHtml (editorState) {
       blockRenderers: {
         atomic: (block) => {
           let data = block.getData()
+          let type = data.get('type')
           let url = data.get('src')
-          if (url) {
-            return `<img src='${url}' />`
+          let caption = data.get('caption')
+          if (url && type == 'image') {
+            return html`
+              <figure>
+                <img src="${url}" alt="${caption}">
+                <figcaption>${caption}</figcaption>
+              </figure>
+            `
+          }
+          if(url && type == 'video'){
+            return html`
+            <figure>
+              <iframe
+                width="560"
+                height="315"
+                src="${url}"
+                className="ld-video-block"
+                frameBorder="0"
+                allowFullScreen>
+              </iframe>
+              <figcaption>${caption}</figcaption>
+            </figure>
+            `
           }
         },
         blockquote: (block) => {


### PR DESCRIPTION
This code improves the html export for the image blocks and the video blocks.
I've added the [common-tags](https://www.npmjs.com/package/common-tags) to clean the indentation on the es6 templates.

I also changed the way the embed videos are handled. Instead of storing the user link and generated the embed link on the render, I store the embed link directly in the state once the user entered the link. Therefore it's easy to generate the html export.

There is just two things missing to get a complete html export (I will open an issue about that).
The links generated through linkify and the hashtags don't have a block type so I can't see a way to make a custom template. I don't have enough experience with draftjs to tell you what to do but I think they should be treated like fragments.