### PR TITLE
add support for iframe within editorStateFromHtml

### DIFF
--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -96,6 +96,17 @@ export function editorStateFromHtml (html, decorator = defaultDecorator) {
         }
       }
 
+      if (nodeName === 'iframe') {
+        return {
+          type: 'atomic',
+          data: {
+            src: node.getAttribute('src'),
+            type: 'video',
+            caption: ''
+          }
+        };
+      }
+
     }
   })(html)
 


### PR DESCRIPTION
Hey @StevenIseki, love this library so far!  While pulling/converting data stored as HTML, I noticed it was stripping out wistia video tags (containing an iframe) when converting data via editorStateFromHtml.  I added support for iframe specifically in the convert function.