### PR TITLE
hotfix stateToHTML setting src as a linkified entity

### DIFF
--- a/example/Example.js
+++ b/example/Example.js
@@ -19,8 +19,8 @@ export default class ExampleEditor extends Component {
     /* examples of initial state */
     const INITIAL_STATE = editorStateFromRaw(RAW)
     //const INITIAL_STATE = editorStateFromRaw({})
-    //const INITIAL_STATE = editorStateFromText('this is a cooel editor... 🏄🌠🏀')
-    //const INITIAL_STATE = editorStateFromHtml(HTML)
+    // const INITIAL_STATE = editorStateFromText('this is a cool editor... 🏄🌠🏀')
+    // const INITIAL_STATE = editorStateFromHtml(HTML)
     //const INITIAL_STATE = editorStateFromHtml('<div />')
     this.state = { value: INITIAL_STATE }
   }

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -60,7 +60,6 @@ export function editorStateFromHtml (html, decorator = defaultDecorator) {
 
       if (nodeName === 'figure') {
         if (!node.children.length) { return null }
-
         let caption = '', title = '', alt = '', src = '', srcSet = '', blockType = 'image'
         let captionNode = node.children[1]
         if (captionNode !== undefined) { caption = captionNode.innerHTML }
@@ -171,7 +170,7 @@ export function editorStateToHtml(editorState) {
     const linkifyMatch = linkify.match(convertedHTML)
     if (linkifyMatch !== null) {
       convertedHTMLLinkify = linkifyMatch.filter(function(match) {
-        if(/(src|ref)=('|")/.test(convertedHTML.slice(match.index - 5, match.index))){
+        if(/(src|ref|set)=('|")/.test(convertedHTML.slice(match.index - 5, match.index))){
           return
         } else {
           return match


### PR DESCRIPTION
When state is converted to HTML, the linkify regex check wasn't catching srcset, and therefor setting image sources like this: `src="<a href="http://whatever.com"></a>"`