### PR TITLE
add support for iframe video blocks & hotfix convertToHTML bug

### DIFF
--- a/example/Example.js
+++ b/example/Example.js
@@ -19,7 +19,7 @@ export default class ExampleEditor extends Component {
     /* examples of initial state */
     const INITIAL_STATE = editorStateFromRaw(RAW)
     //const INITIAL_STATE = editorStateFromRaw({})
-    //const INITIAL_STATE = editorStateFromText('this is a cooel editor... 🏄🌠🏀')
+    //const INITIAL_STATE = editorStateFromText('this is a cool editor... 🏄🌠🏀')
     //const INITIAL_STATE = editorStateFromHtml(HTML)
     //const INITIAL_STATE = editorStateFromHtml('<div />')
     this.state = { value: INITIAL_STATE }

--- a/lib/utils/convert.js
+++ b/lib/utils/convert.js
@@ -6,8 +6,8 @@ Object.defineProperty(exports, "__esModule", {
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-var _templateObject = _taggedTemplateLiteral(['\n              <figure>\n                <img src="', '" srcset="', '" alt="', '" title="', '" class="ld-image-block">\n                <figcaption class="ld-image-caption">', '</figcaption>\n              </figure>\n            '], ['\n              <figure>\n                <img src="', '" srcset="', '" alt="', '" title="', '" class="ld-image-block">\n                <figcaption class="ld-image-caption">', '</figcaption>\n              </figure>\n            ']),
-    _templateObject2 = _taggedTemplateLiteral(['\n            <figure>\n              <iframe width="560" height="315" src="', '" class="ld-video-block" frameBorder="0" allowFullScreen>\n              </iframe>\n              <figcaption class="ld-video-caption">', '</figcaption>\n            </figure>\n            '], ['\n            <figure>\n              <iframe width="560" height="315" src="', '" class="ld-video-block" frameBorder="0" allowFullScreen>\n              </iframe>\n              <figcaption class="ld-video-caption">', '</figcaption>\n            </figure>\n            ']);
+var _templateObject = _taggedTemplateLiteral(['              <figure>                <img src="', '" srcset="', '" alt="', '" title="', '" class="ld-image-block">                <figcaption class="ld-image-caption">', '</figcaption>              </figure>            '], ['\\\n              <figure>\\\n                <img src="', '" srcset="', '" alt="', '" title="', '" class="ld-image-block">\\\n                <figcaption class="ld-image-caption">', '</figcaption>\\\n              </figure>\\\n            ']),
+    _templateObject2 = _taggedTemplateLiteral(['            <figure>              <iframe width="560" height="315" src="', '" class="ld-video-block" frameBorder="0" allowFullScreen>              </iframe>              <figcaption class="ld-video-caption">', '</figcaption>            </figure>            '], ['\\\n            <figure>\\\n              <iframe width="560" height="315" src="', '" class="ld-video-block" frameBorder="0" allowFullScreen>\\\n              </iframe>\\\n              <figcaption class="ld-video-caption">', '</figcaption>\\\n            </figure>\\\n            ']);
 
 exports.editorStateFromHtml = editorStateFromHtml;
 exports.editorStateToHtml = editorStateToHtml;
@@ -139,7 +139,7 @@ function editorStateFromHtml(html) {
 
         if (blockNode !== undefined) {
           _src = _blockType === 'video' ? node.children[0].getAttribute('src') : blockNode.src;
-          _srcSet = blockNode.srcset;
+          _srcSet = blockNode.srcset || node.children[0].getAttribute('src');
           _alt = blockNode.alt;
           _title = blockNode.title;
         }

--- a/lib/utils/convert.js
+++ b/lib/utils/convert.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _templateObject = _taggedTemplateLiteral(['\n              <figure>\n                <img src="', '" srcset="', '" alt="', '" title="', '" class="ld-image-block">\n                <figcaption class="ld-image-caption">', '</figcaption>\n              </figure>\n            '], ['\n              <figure>\n                <img src="', '" srcset="', '" alt="', '" title="', '" class="ld-image-block">\n                <figcaption class="ld-image-caption">', '</figcaption>\n              </figure>\n            ']),
-    _templateObject2 = _taggedTemplateLiteral(['\n            <figure>\n              <iframe\n                width="560"\n                height="315"\n                src="', '"\n                class="ld-video-block"\n                frameBorder="0"\n                allowFullScreen>\n              </iframe>\n              <figcaption class="ld-video-caption">', '</figcaption>\n            </figure>\n            '], ['\n            <figure>\n              <iframe\n                width="560"\n                height="315"\n                src="', '"\n                class="ld-video-block"\n                frameBorder="0"\n                allowFullScreen>\n              </iframe>\n              <figcaption class="ld-video-caption">', '</figcaption>\n            </figure>\n            ']);
+    _templateObject2 = _taggedTemplateLiteral(['\n            <figure>\n              <iframe width="560" height="315" src="', '" class="ld-video-block" frameBorder="0" allowFullScreen>\n              </iframe>\n              <figcaption class="ld-video-caption">', '</figcaption>\n            </figure>\n            '], ['\n            <figure>\n              <iframe width="560" height="315" src="', '" class="ld-video-block" frameBorder="0" allowFullScreen>\n              </iframe>\n              <figcaption class="ld-video-caption">', '</figcaption>\n            </figure>\n            ']);
 
 exports.editorStateFromHtml = editorStateFromHtml;
 exports.editorStateToHtml = editorStateToHtml;
@@ -104,6 +104,17 @@ function editorStateFromHtml(html) {
         };
       }
 
+      if (nodeName === 'iframe' && node.className !== 'ld-video-block') {
+        return {
+          type: 'atomic',
+          data: {
+            src: node.getAttribute('src'),
+            type: 'video',
+            caption: ''
+          }
+        };
+      }
+
       if (nodeName === 'figure') {
         if (!node.children.length) {
           return null;
@@ -121,16 +132,16 @@ function editorStateFromHtml(html) {
         }
 
         var blockNode = node.children[0];
-        if (blockNode !== undefined) {
-          _src = blockNode.src;
-          _srcSet = blockNode.srcset;
-          _alt = blockNode.alt;
-          _title = blockNode.title;
-        }
-
         var type = blockNode.tagName.toLowerCase();
         if (type === 'iframe') {
           _blockType = 'video';
+        }
+
+        if (blockNode !== undefined) {
+          _src = _blockType === 'video' ? node.children[0].getAttribute('src') : blockNode.src;
+          _srcSet = blockNode.srcset;
+          _alt = blockNode.alt;
+          _title = blockNode.title;
         }
 
         return {
@@ -217,7 +228,7 @@ function editorStateToHtml(editorState) {
       var linkifyMatch = linkify.match(convertedHTML);
       if (linkifyMatch !== null) {
         convertedHTMLLinkify = linkifyMatch.filter(function (match) {
-          if (/(src|ref)=('|")/.test(convertedHTML.slice(match.index - 5, match.index))) {
+          if (/(src|ref|set)=('|")/.test(convertedHTML.slice(match.index - 5, match.index))) {
             return;
           } else {
             return match;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "last-draft",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Last Draft... A Draft.js Editor",
   "main": "lib/index.js",
   "scripts": {

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -82,7 +82,7 @@ export function editorStateFromHtml (html, decorator = defaultDecorator) {
 
         if (blockNode !== undefined) {
           src = blockType === 'video' ? node.children[0].getAttribute('src') : blockNode.src
-          srcSet = blockNode.srcset
+          srcSet = blockNode.srcset || node.children[0].getAttribute('src')
           alt = blockNode.alt
           title = blockNode.title
         }

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -58,6 +58,17 @@ export function editorStateFromHtml (html, decorator = defaultDecorator) {
         }
       }
 
+      if (nodeName === 'iframe' && node.className !== 'ld-video-block') {
+        return {
+          type: 'atomic',
+          data: {
+            src: node.getAttribute('src'),
+            type: 'video',
+            caption: ''
+          }
+        };
+      }
+
       if (nodeName === 'figure') {
         if (!node.children.length) { return null }
 
@@ -66,15 +77,15 @@ export function editorStateFromHtml (html, decorator = defaultDecorator) {
         if (captionNode !== undefined) { caption = captionNode.innerHTML }
 
         let blockNode = node.children[0]
+        let type = blockNode.tagName.toLowerCase()
+        if (type === 'iframe') { blockType = 'video' }
+
         if (blockNode !== undefined) {
-          src = blockNode.src
+          src = blockType === 'video' ? node.children[0].getAttribute('src') : blockNode.src
           srcSet = blockNode.srcset
           alt = blockNode.alt
           title = blockNode.title
         }
-
-        let type = blockNode.tagName.toLowerCase()
-        if (type === 'iframe') { blockType = 'video' }
 
         return {
           type: 'atomic',
@@ -146,13 +157,7 @@ export function editorStateToHtml(editorState) {
           if (src && type == 'video') {
             return html`
             <figure>
-              <iframe
-                width="560"
-                height="315"
-                src="${src}"
-                class="ld-video-block"
-                frameBorder="0"
-                allowFullScreen>
+              <iframe width="560" height="315" src="${src}" class="ld-video-block" frameBorder="0" allowFullScreen>
               </iframe>
               <figcaption class="ld-video-caption">${caption}</figcaption>
             </figure>
@@ -171,7 +176,7 @@ export function editorStateToHtml(editorState) {
     const linkifyMatch = linkify.match(convertedHTML)
     if (linkifyMatch !== null) {
       convertedHTMLLinkify = linkifyMatch.filter(function(match) {
-        if(/(src|ref)=('|")/.test(convertedHTML.slice(match.index - 5, match.index))){
+        if(/(src|ref|set)=('|")/.test(convertedHTML.slice(match.index - 5, match.index))){
           return
         } else {
           return match

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -147,20 +147,20 @@ export function editorStateToHtml(editorState) {
           if (title === '') { title = caption }
 
           if (src && type == 'image') {
-            return html`
-              <figure>
-                <img src="${src}" srcset="${srcSet}" alt="${alt}" title="${title}" class="ld-image-block">
-                <figcaption class="ld-image-caption">${caption}</figcaption>
-              </figure>
+            return html`\
+              <figure>\
+                <img src="${src}" srcset="${srcSet}" alt="${alt}" title="${title}" class="ld-image-block">\
+                <figcaption class="ld-image-caption">${caption}</figcaption>\
+              </figure>\
             `
           }
           if (src && type == 'video') {
-            return html`
-            <figure>
-              <iframe width="560" height="315" src="${src}" class="ld-video-block" frameBorder="0" allowFullScreen>
-              </iframe>
-              <figcaption class="ld-video-caption">${caption}</figcaption>
-            </figure>
+            return html`\
+            <figure>\
+              <iframe width="560" height="315" src="${src}" class="ld-video-block" frameBorder="0" allowFullScreen>\
+              </iframe>\
+              <figcaption class="ld-video-caption">${caption}</figcaption>\
+            </figure>\
             `
           }
         },


### PR DESCRIPTION
- Fixes bug when state is converted to HTML, the linkify regex check wasn't catching srcset, and therefor setting image sources like this: `src="<a href="http://whatever.com"></a>"`
- Adds support for video iframes. I noticed this bug when converting from / to HTML was stripping out wistia video tags (containing an iframe)