### PR TITLE
Give default options to image after upload

### DIFF
--- a/lib/components/Editor.js
+++ b/lib/components/Editor.js
@@ -720,7 +720,7 @@ var _default = function (_Component) {
           if (srcSet === undefined) {
             srcSet = data.src;
           }
-          var imageData = { src: data.src, srcSet: srcSet, type: 'image' };
+          var imageData = { src: data.src, srcSet: srcSet, alt: 'image', caption: '', type: 'image' };
           _this2.onChange((0, _insertDataBlock2.default)(editorState, imageData, selection));
           _this2.setState({ uploading: false });
         });

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -426,7 +426,7 @@ export default class extends Component {
         /* show loaded image */
         let srcSet = data.srcSet
         if (srcSet === undefined) { srcSet = data.src }
-        const imageData = {src: data.src, srcSet: srcSet, type: 'image'}
+        const imageData = {src: data.src, srcSet: srcSet, alt: 'image', caption: '', type: 'image'}
         this.onChange(insertDataBlock(editorState, imageData, selection))
         this.setState({ uploading: false })
       })


### PR DESCRIPTION
After uploading the image and in case I do not provide any caption for the image, when I try to  convert the document to html(editorStateToHtml), the caption always be undefined. So this fix give basic default options for image after upload(bye bye undefined)