### PR TITLE
Fix bug with empty text in image plugin

### DIFF
--- a/lib/components/Editor.js
+++ b/lib/components/Editor.js
@@ -720,7 +720,7 @@ var _default = function (_Component) {
           if (srcSet === undefined) {
             srcSet = data.src;
           }
-          var imageData = { src: data.src, srcSet: srcSet, type: 'image' };
+          var imageData = { src: data.src, srcSet: srcSet, type: 'image', caption: data.caption || '' };
           _this2.onChange((0, _insertDataBlock2.default)(editorState, imageData, selection));
           _this2.setState({ uploading: false });
         });

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -426,7 +426,7 @@ export default class extends Component {
         /* show loaded image */
         let srcSet = data.srcSet
         if (srcSet === undefined) { srcSet = data.src }
-        const imageData = {src: data.src, srcSet: srcSet, type: 'image'}
+        const imageData = {src: data.src, srcSet: srcSet, type: 'image', caption: data.caption || ''}
         this.onChange(insertDataBlock(editorState, imageData, selection))
         this.setState({ uploading: false })
       })


### PR DESCRIPTION
If you leave the caption field empty, the result will be a caption which says undefined.
This pr fix so this will instead be an empty string